### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -89,7 +89,7 @@ jobs:
           # github-token: # optional, default is ${{ github.token }}
    #   - name: Publish to Registry
    #     id: publish
-   #     uses: elgohr/Publish-Docker-Github-Action@2.12
+   #     uses: elgohr/Publish-Docker-Github-Action@v5
    #     with:
    #       name: hjin/es-ik
    #       username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore